### PR TITLE
chore(engine): use >= instead of ~ for engine version to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "benchmark": "make benchmark"
   },
   "engines": {
-    "node": "~0.10.22"
+    "node": ">=0.10.22"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
#### What?

Update the engine semver definition to avoid warning as `npm WARN engine ak-eventemitter@0.0.5: wanted: {"node":"~0.10.22"} (current: {"node":"4.2.3","npm":"2.14.7"})`

#### How?

Use `>=` instead of `~` for semver